### PR TITLE
Adds max-age header for responses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN GO111MODULE=on GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -ldflags '-
 FROM skpr/base:1.x
 
 ENV PROXY_APP_ADDR=":8080"
+ENV PROXY_APP_MAX_AGE="5m"
 
 COPY --from=builder /go/src/github.com/skpr/proxy-app/proxy-app /usr/local/bin/proxy-app
 RUN chmod +x /usr/local/bin/proxy-app

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strings"
+	"time"
 )
 
 // RunParams is passed to the Run() function.
@@ -21,6 +22,8 @@ type RunParams struct {
 	Password string
 	// TrimPathPrefix from backend requests.
 	TrimPathPrefix string
+	// MaxAge applied to a response.
+	MaxAge string
 }
 
 // Validate the server parameters.
@@ -33,6 +36,10 @@ func (p RunParams) Validate() error {
 		return fmt.Errorf("not provided: endpoint")
 	}
 
+	if p.MaxAge == "" {
+		return fmt.Errorf("not provided: max-age")
+	}
+
 	return nil
 }
 
@@ -40,6 +47,11 @@ func (p RunParams) Validate() error {
 func Run(params RunParams) error {
 	if err := params.Validate(); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	maxAge, err := time.ParseDuration(params.MaxAge)
+	if err != nil {
+		return fmt.Errorf("failed to parse max age: %w", err)
 	}
 
 	endpoint, err := url.Parse(params.Endpoint)
@@ -67,6 +79,11 @@ func Run(params RunParams) error {
 		if params.TrimPathPrefix != "" {
 			r.URL.Path = strings.TrimPrefix(r.URL.Path, params.TrimPathPrefix)
 		}
+	}
+
+	proxy.ModifyResponse = func(r *http.Response) error {
+		r.Header.Set("Cache-Control", fmt.Sprintf("max-age:%v, public", maxAge.Seconds()))
+		return nil
 	}
 
 	// Debug messaging - also add target to LB.

--- a/main.go
+++ b/main.go
@@ -19,6 +19,8 @@ const (
 	EnvSkprConfigKeyPassword = "PROXY_APP_CONFIG_KEY_PASSWORD"
 	// EnvSkprConfigKeyTrimPathPrefix used to load the path prefix value from Skpr config.
 	EnvSkprConfigKeyTrimPathPrefix = "PROXY_APP_CONFIG_KEY_TRIM_PATH_PREFIX"
+	// EnvSkprConfigKeyMaxAge used to set the max-age for all responses.
+	EnvSkprConfigKeyMaxAge = "PROXY_APP_CONFIG_KEY_MAX_AGE"
 
 	// EnvAddr sets the address for the proxy application.
 	EnvAddr = "PROXY_APP_ADDR"
@@ -30,6 +32,8 @@ const (
 	EnvPassword = "PROXY_APP_PASSWORD"
 	// EnvTrimPathPrefix strips the path prefix from backend requests.
 	EnvTrimPathPrefix = "PROXY_APP_TRIM_PATH_PREFIX"
+	// EnvMaxAge used to set the max-age for all responses.
+	EnvMaxAge = "PROXY_APP_MAX_AGE"
 )
 
 func main() {
@@ -44,6 +48,7 @@ func main() {
 		Username:       skprclient.GetWithFallback(os.Getenv(EnvSkprConfigKeyUsername), os.Getenv(EnvUsername)),
 		Password:       skprclient.GetWithFallback(os.Getenv(EnvSkprConfigKeyPassword), os.Getenv(EnvPassword)),
 		TrimPathPrefix: skprclient.GetWithFallback(os.Getenv(EnvSkprConfigKeyTrimPathPrefix), os.Getenv(EnvTrimPathPrefix)),
+		MaxAge:         skprclient.GetWithFallback(os.Getenv(EnvSkprConfigKeyMaxAge), os.Getenv(EnvMaxAge)),
 	}
 
 	if err := server.Run(params); err != nil {


### PR DESCRIPTION
* Adds max-age header for all proxied responses.
* Defaults to 5 minutes.